### PR TITLE
Make balancer fan out to multiple consumers and multiple copies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1935,7 +1935,7 @@ dependencies = [
 
 [[package]]
 name = "mtransaction"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-stream",
  "base64 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mtransaction"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 [[bin]]

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,24 @@
+name = mtransaction
+
+help:
+	@echo "Usage:"
+	@echo "    build-server    builds the dev version of the mtransaction server"
+	@echo "    build           compile the package"
+	@echo "    image           builds $(name) docker image"
+	@echo "    help            show this help"
+
 .PHONY: build-all build-server build-server-release run-server clean run-client run-client-local
 .DEFAULT_GOAL := build-all
 
-cert-server:
-	./scripts/cert-server.bash $(cmd) $(host)
+CERT_DIR = certs
+JWT_KEY = $(CERT_DIR)/jwtRS256.key
+
+$(CERT_DIR)/ca.cert: $(CERT_DIR)/openssl.server.conf
+	openssl req -x509 -newkey rsa:4096 -days 3650 -nodes -keyout "$(CERT_DIR)/ca.key" -out "$(CERT_DIR)/ca.cert" -subj "/CN=Marinade"
+
+$(JWT_KEY):
+	ssh-keygen -t rsa -b 4096 -m PEM -f $@ -N ""
+	openssl rsa -in $@ -pubout -outform PEM -out $@.pub
 
 cert-client:
 	./scripts/cert-client.bash $(cmd) $(validator)
@@ -35,16 +51,33 @@ run-server: build-server
 		--tls-grpc-ca-cert        ./certs/ca.cert \
 		--jwt-public-key          ./certs/jwtRS256.key.pub
 
-run-client-local: build-client
+run-server-local: build-server
+	cargo run --bin mtx-server -- \
+		--stake-override-identity foo     bar \
+		--stake-override-sol      1000000 2000000 \
+		--tls-grpc-server-cert    ./certs/localhost.cert \
+		--tls-grpc-server-key     ./certs/localhost.key \
+		--tls-grpc-ca-cert        ./certs/ca.cert \
+
+run-client-rpc-devnet: build-client
 	cargo run --bin mtx-client -- \
 		--tls-grpc-ca-cert     ./certs/ca.cert \
-		--grpc-urls-file       ./client-config.yaml \
+		--grpc-urls-file       ./client.yml \
 		--tls-grpc-client-key  ./certs/client.$(client).key \
 		--tls-grpc-client-cert ./certs/client.$(client).cert \
-		--rpc-url              http://127.0.0.1:8899
+		--rpc-url              https://api.devnet.solana.com
+
+run-client-rpc-mainnet: build-client
+	cargo run --bin mtx-client -- \
+		--tls-grpc-ca-cert     ./certs/ca.cert \
+		--grpc-urls-file       ./client.yml \
+		--tls-grpc-client-key  ./certs/client.$(client).key \
+		--tls-grpc-client-cert ./certs/client.$(client).cert \
+		--rpc-url              `<mainnet-rpc.txt`
 
 run-client-blackhole: build-client
 	cargo run --bin mtx-client -- \
+		--grpc-urls-file       ./client.yml \
 		--tls-grpc-ca-cert     ./certs/ca.cert \
 		--tls-grpc-client-key  ./certs/client.$(client).key \
 		--tls-grpc-client-cert ./certs/client.$(client).cert \

--- a/client/grpc_client.rs
+++ b/client/grpc_client.rs
@@ -171,7 +171,7 @@ pub async fn spawn_grpc_client(
     )
     .await
     .map(|v| {
-      info!("Stream ended from gRPC server: {:?}, {:?}", grpc_host, v);
-      v
+        info!("Stream ended from gRPC server: {:?}, {:?}", grpc_host, v);
+        v
     })
 }

--- a/client/main.rs
+++ b/client/main.rs
@@ -98,8 +98,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         params.throttle_parallel,
     );
 
-    let all_tasks: RwLock<HashMap<String, JoinHandle<()>>> =
-       RwLock::new(HashMap::new());
+    let all_tasks: RwLock<HashMap<String, JoinHandle<()>>> = RwLock::new(HashMap::new());
 
     build_tasks(
         grpc_urls_from_file.clone(),
@@ -271,7 +270,6 @@ async fn build_tasks(
 ) {
     let mut all_tasks = all_tasks.write().await;
     for i in grpc_urls {
-
         let grpc_parsed_url: Uri = i.parse().expect("failed to parse grpc url");
 
         let tls_grpc_ca_cert = params.tls_grpc_ca_cert.clone();

--- a/server/main.rs
+++ b/server/main.rs
@@ -16,6 +16,12 @@ use std::sync::Arc;
 use structopt::StructOpt;
 use tokio::sync::RwLock;
 
+pub const N_COPIES: usize = 2;
+pub const N_LEADERS: u64 = 7;
+pub const N_CONSUMERS: usize = 3;
+pub const LEADER_REFRESH_SECONDS: u64 = 3600;
+pub const NODES_REFRESH_SECONDS: u64 = 60;
+
 #[derive(Debug, StructOpt)]
 struct Params {
     #[structopt(long = "tls-grpc-server-cert")]
@@ -70,7 +76,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let params = Params::from_args();
 
     let client = Arc::new(solana_client(params.rpc_url, params.rpc_commitment));
-    let balancer = Arc::new(RwLock::new(Balancer::new()));
+    let balancer = Arc::new(RwLock::new(Balancer::default()));
 
     let pubsub_client = Arc::new(PubsubClient::new(&params.ws_rpc_url).await?);
 


### PR DESCRIPTION
Current master sends transactions though a single random consumer.

This change makes is so that the transactions are send through multiple consumers, each consumer delivers to a portion of the leader's TPUs.  On top of that, it is possible to set N_COPIES > 1 which will send each transction N_COPIES times, from separate consumers.